### PR TITLE
chore(dtocean-hydrodynamics): improve tests and update dead link

### DIFF
--- a/packages/dtocean-hydrodynamics/README.md
+++ b/packages/dtocean-hydrodynamics/README.md
@@ -136,6 +136,20 @@ poetry run ruff
 poetry run pyright src
 ```
 
+The above tests can be run across all compatible Python versions using
+[tox](https://tox.wiki/) and [tox-uv](https://github.com/tox-dev/tox-uv). To
+install:
+
+```sh
+poetry install --with test --with test-extras --with audit --with tox
+```
+
+To run the tests:
+
+```sh
+poetry run tox
+```
+
 ## Contributing
 
 Please see the [dtocean](https://github.com/DTOcean/dtocean) GitHub repository
@@ -144,7 +158,7 @@ for contributing guidelines.
 ## Credits
 
 This package was initially created as part of the [EU DTOcean project](
-https://www.dtoceanplus.eu/About-DTOceanPlus/History) by:
+https://cordis.europa.eu/project/id/608597) by:
 
 * Francesco Ferri at [Aalborg University](https://www.en.aau.dk/)
 * Pau Mercade Ruiz at [Aalborg University](https://www.en.aau.dk/)

--- a/packages/dtocean-hydrodynamics/pyproject.toml
+++ b/packages/dtocean-hydrodynamics/pyproject.toml
@@ -62,7 +62,7 @@ numpy = "^2.3.5"
 pandas = "^3.0.1"
 pyopengl = "^3.1.7"
 scikit-learn = "^1.6.0"
-scipy = "^1.14.1"
+scipy = "^1.17.0"
 shapely = "^2.0.6"
 polite-config = { path = "../polite-config", develop = true }
 contourpy = "^1.3.1"

--- a/packages/dtocean-hydrodynamics/tests/dtocean_plugins/modules/test_modules_hydrodynamics.py
+++ b/packages/dtocean-hydrodynamics/tests/dtocean_plugins/modules/test_modules_hydrodynamics.py
@@ -284,7 +284,6 @@ def test_tidal_interface_entry_fail(
 
     with pytest.raises(ValueError):
         interface.connect(debug_entry=True)
-        interface.connect(debug_entry=True)
 
 
 def test_convert_results(outputs_wp2_wave):

--- a/packages/dtocean-hydrodynamics/tests/dtocean_wec/projects/load_nemoh/conftest.py
+++ b/packages/dtocean-hydrodynamics/tests/dtocean_wec/projects/load_nemoh/conftest.py
@@ -81,7 +81,7 @@ def nehom_path(mocker, monkeypatch, qtbot, tmp_path):
         assert main_window.form_power is not None
         assert main_window.form_power.isEnabled()
 
-    qtbot.waitUntil(is_enabled)
+    qtbot.waitUntil(is_enabled, timeout=30000)
 
     return run_nehom_path / "hydrodynamic"
 

--- a/packages/dtocean-hydrodynamics/tests/dtocean_wec/projects/run_nemoh/test_run_nemoh_form_hyd.py
+++ b/packages/dtocean-hydrodynamics/tests/dtocean_wec/projects/run_nemoh/test_run_nemoh_form_hyd.py
@@ -38,4 +38,4 @@ def test_calculate_again(
     def is_enabled():
         assert form_hyd_calculated.btn_calculate_t2.isEnabled()
 
-    qtbot.waitUntil(is_enabled)
+    qtbot.waitUntil(is_enabled, timeout=30000)

--- a/poetry.lock
+++ b/poetry.lock
@@ -892,7 +892,7 @@ polite-config = {path = "../polite-config", develop = true}
 pyopengl = "^3.1.7"
 pyside6 = "^6.9.0"
 scikit-learn = "^1.6.0"
-scipy = "^1.14.1"
+scipy = "^1.17.0"
 shapely = "^2.0.6"
 shiboken6 = "^6.9.0"
 


### PR DESCRIPTION
This PR updates the following:

- Increased timeout lengths for tests that require NEMOH to run in the background
- Replaces dead link to DTOcean project archival info
- Updated minimum SciPy version
- Fixed typo
