### PR TITLE
fix(dtocean-economics): allow partially defined records

### DIFF
--- a/packages/dtocean-economics/src/dtocean_plugins/themes/economics.py
+++ b/packages/dtocean-economics/src/dtocean_plugins/themes/economics.py
@@ -432,8 +432,30 @@ class EconomicInterface(ThemeInterface):
         )
         capex_bom = capex_bom.convert_dtypes()
 
+        # Try to infer the project lifetime
+        lifetime = None
+
+        if self.data.lifetime is not None:
+            lifetime = self.data.lifetime
+        else:
+            lifetimes: list[int] = []
+
+            if self.data.opex_per_year is not None:
+                lifetimes.append(self.data.opex_per_year.index.max())
+            if self.data.energy_per_year is not None:
+                lifetimes.append(self.data.energy_per_year.index.max())
+
+            if lifetimes:
+                lifetime = max(lifetimes)
+
         if self.data.opex_per_year is not None:
             opex_bom = self.data.opex_per_year.copy()
+            assert isinstance(opex_bom, pd.DataFrame)
+
+            # Fill missing years with zero
+            assert lifetime is not None
+            opex_bom = opex_bom.reindex(range(lifetime + 1), fill_value=0.0)
+
             opex_bom.index.name = "project_year"
             opex_bom = opex_bom.reset_index()
 
@@ -462,21 +484,32 @@ class EconomicInterface(ThemeInterface):
                 )
             else:
                 opex_bom = opex_bom.set_index("project_year")
-                opex_bom += self.data.externalities_opex
+                opex_bom.loc[1:] += self.data.externalities_opex
                 opex_bom = opex_bom.reset_index()
 
         # Prepare energy
         if self.data.network_efficiency is not None:
             net_coeff = self.data.network_efficiency
         else:
-            net_coeff = 1
+            net_coeff = 1.0
+
+        assert isinstance(net_coeff, float)
 
         # Convert energy to Wh
         MWh_to_Wh = 1e6
 
-        if self.data.energy_per_year is not None:  #
-            energy_record = self.data.energy_per_year.copy() * MWh_to_Wh
-            energy_record = energy_record * net_coeff
+        if self.data.energy_per_year is not None:
+            energy_record = self.data.energy_per_year.copy()
+            assert isinstance(energy_record, pd.DataFrame)
+            energy_record = energy_record * MWh_to_Wh * net_coeff
+
+            # Fill missing years with zero
+            assert lifetime is not None
+            energy_record = energy_record.reindex(
+                range(lifetime + 1),
+                fill_value=0.0,
+            )
+
             energy_record.index.name = "project_year"
             energy_record = energy_record.reset_index()
 
@@ -588,6 +621,10 @@ def _get_outputs(
             )
 
     if not opex_bom.empty:
+        max_year = opex_bom["project_year"].max()
+        if len(opex_bom) != max_year + 1:
+            raise ValueError("Not all project years have values in OPEX bom")
+
         opex_by_year = opex_bom.set_index("project_year")
         opex_year_zero = opex_by_year.loc[0]
         assert isinstance(opex_year_zero, pd.Series)
@@ -598,6 +635,12 @@ def _get_outputs(
         discounted_opex = get_discounted_values(opex_bom, discount_rate)
 
     if not energy_record.empty:
+        max_year = energy_record["project_year"].max()
+        if len(energy_record) != max_year + 1:
+            raise ValueError(
+                "Not all project years have values in energy record"
+            )
+
         energy_by_year = energy_record.set_index("project_year")
         energy_total = energy_by_year.sum()
         discounted_energy = get_discounted_values(energy_record, discount_rate)

--- a/packages/dtocean-economics/test_data/inputs_economics.py
+++ b/packages/dtocean-economics/test_data/inputs_economics.py
@@ -39,7 +39,7 @@ install_bom = pd.DataFrame(install_bom_dict)
 opex_bom_dict = {"Cost": [1000, 2000], "Year": [3, 4]}
 opex_bom = pd.DataFrame(opex_bom_dict)
 
-energy_record_dict = {"Energy": [10000, 20000], "Year": [3, 4]}
+energy_record_dict = {"Energy": [10000, 20000, 0], "Year": [3, 4, 5]}
 energy_record = pd.DataFrame(energy_record_dict)
 
 

--- a/packages/dtocean-economics/tests/dtocean_plugins/themes/test_themes_economics.py
+++ b/packages/dtocean-economics/tests/dtocean_plugins/themes/test_themes_economics.py
@@ -223,15 +223,22 @@ def test_economics_interface_entry(
     assert externalities_opex == 1e3
 
     expected_opex_bom_dict = {
-        "project_year": [3, 4],
-        "Cost": [1000.0 + externalities_opex, 2000.0 + externalities_opex],
+        "project_year": [0, 1, 2, 3, 4, 5],
+        "Cost": [
+            0.0,
+            0.0 + externalities_opex,
+            0.0 + externalities_opex,
+            1000.0 + externalities_opex,
+            2000.0 + externalities_opex,
+            0.0 + externalities_opex,
+        ],
     }
     expected_opex_bom = pd.DataFrame(expected_opex_bom_dict)
     pd.testing.assert_frame_equal(expected_opex_bom, opex_bom)
 
     expected_energy_record_dict = {
-        "project_year": [3, 4],
-        "Energy": [10000.0, 20000.0],
+        "project_year": [0, 1, 2, 3, 4, 5],
+        "Energy": [0.0, 0.0, 0.0, 10000.0, 20000.0, 0.0],
     }
     expected_energy_record = pd.DataFrame(expected_energy_record_dict)
     expected_energy_record["Energy"] = (
@@ -1072,8 +1079,7 @@ def test_get_outputs_0_energy_only(energy_record_0):
         assert outputs[key] is not None
 
 
-@pytest.fixture()
-def opex_costs_0_non_zero_year_0():
+def test_get_outputs_opex_non_zero_year_0():
     opex_dict = {
         "project_year": [0, 1, 2, 3],
         "cost 0": [
@@ -1083,22 +1089,60 @@ def opex_costs_0_non_zero_year_0():
             YEAR_THREE,
         ],
     }
-    opex_df = pd.DataFrame(opex_dict)
-    return opex_df
-
-
-def test_get_outputs_0_opex_non_zero_year_0(opex_costs_0_non_zero_year_0):
+    opex_non_zero_year_0 = pd.DataFrame(opex_dict)
     discount_rate = 1 / 5
     with pytest.raises(ValueError) as exc:
         _get_outputs(
             pd.DataFrame(),
-            opex_costs_0_non_zero_year_0,
+            opex_non_zero_year_0,
             pd.DataFrame(),
             discount_rate,
             None,
             None,
         )
     assert "OPEX must be zero for year 0" in str(exc)
+
+
+def test_get_outputs_opex_missing_years():
+    opex_dict = {
+        "project_year": [1, 2, 3],
+        "cost 0": [
+            YEAR_ONE,
+            YEAR_TWO,
+            YEAR_THREE,
+        ],
+    }
+    opex_missing_years = pd.DataFrame(opex_dict)
+    discount_rate = 1 / 5
+    with pytest.raises(ValueError) as exc:
+        _get_outputs(
+            pd.DataFrame(),
+            opex_missing_years,
+            pd.DataFrame(),
+            discount_rate,
+            None,
+            None,
+        )
+    assert "Not all project years have values in OPEX bom" in str(exc)
+
+
+def test_get_outputs_energy_missing_years():
+    energy_dict = {
+        "project_year": [1, 2, 3],
+        "energy 0": [YEAR_ONE * 1e6, YEAR_TWO * 1e6, YEAR_THREE * 1e6],
+    }
+    energy_missing_years = pd.DataFrame(energy_dict)
+    discount_rate = 1 / 5
+    with pytest.raises(ValueError) as exc:
+        _get_outputs(
+            pd.DataFrame(),
+            pd.DataFrame(),
+            energy_missing_years,
+            discount_rate,
+            None,
+            None,
+        )
+    assert "Not all project years have values in energy record" in str(exc)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This commit allow inputs for the OPEX bom and energy record to have some years undefined. If the project lifetime is not set, it will try to infer it from the maximum given year in either the OPEX bom or the energy record.